### PR TITLE
fix: ID alarms by account, not just name

### DIFF
--- a/src/DeploymentSafetyEnforcer.function.ts
+++ b/src/DeploymentSafetyEnforcer.function.ts
@@ -359,16 +359,21 @@ const calculateBakeActions = async (
       const results = await getAlarmStates(alarms, cloudwatchClient);
       results.forEach(({ alarm, state }) => {
         if (state === 'IN_ALARM') {
-          failedAlarmsByName.add(alarm.alarmName);
+          failedAlarmsByName.add(`${roleArn}\n${alarm.alarmName}`);
         } else if (state === 'MISSING' && alarm.treatMissingAlarm === 'REJECT') {
-          failedAlarmsByName.add(alarm.alarmName);
+          failedAlarmsByName.add(`${roleArn}\n${alarm.alarmName}`);
         }
       });
     }),
   );
 
   pendingAlarmDecision.forEach(({ approvalProps, alarmSettings }) => {
-    const failedAlarms = alarmSettings.filter((alarm) => failedAlarmsByName.has(alarm.alarmName));
+    const failedAlarms = alarmSettings.filter(
+      (alarm) => failedAlarmsByName.has(
+        `${alarm.assumeRoleArn ?? NO_ROLE_PLACEHOLDER}\n${alarm.alarmName}`,
+      ),
+    );
+
     if (failedAlarms.length > 0) {
       decisions.push({
         approvalProps,


### PR DESCRIPTION
If multiple bake stages use alarms with the same names, a failure in one cascades to others. By adding the role ARN, we limit the match to account as well.