### PR TITLE
feat: buildEnforcer() returns created instance

### DIFF
--- a/API.md
+++ b/API.md
@@ -145,7 +145,7 @@ set of SSM ChangeCalendar name or ARNs to block on.
 ##### `buildEnforcer` <a name="buildEnforcer" id="cdk-deployment-constructs.CodePipelineHelper.buildEnforcer"></a>
 
 ```typescript
-public buildEnforcer(): void
+public buildEnforcer(): DeploymentSafetyEnforcer
 ```
 
 Performs one-time building of resources. May not be called multiple times.

--- a/src/CodePipelineHelper.ts
+++ b/src/CodePipelineHelper.ts
@@ -149,12 +149,13 @@ export class CodePipelineHelper extends Construct {
     if (this.built) {
       throw new Error('build() has already been called: can only call it once');
     }
-    this.doBuild();
+    const enforcer = this.doBuild();
     this.built = true;
+    return enforcer;
   }
 
   private doBuild() {
-    new DeploymentSafetyEnforcer(this, 'Enforcer', {
+    return new DeploymentSafetyEnforcer(this, 'Enforcer', {
       pipeline: this.pipeline.pipeline,
       changeCalendars: this.changeCalendarsByStageName,
       bakeSteps: this.bakeSteps,


### PR DESCRIPTION
Exposing this enforcer will allow consumers access to internals, such as the recently-added metric instances.