### PR TITLE
fix: Metrics always provide a namespace

### DIFF
--- a/src/DeploymentSafetyEnforcer.function.ts
+++ b/src/DeploymentSafetyEnforcer.function.ts
@@ -550,8 +550,9 @@ const execute = async (
       requestId,
       pipelineName: settings.pipelineName,
       rejectedBakeActions: rejectBakeActions.length,
-      settings: settings.metricsSettings ?? {
+      settings: {
         namespace: 'DeploymentSafetyEnforcer',
+        ...settings.metricsSettings,
       },
     });
   }


### PR DESCRIPTION
Fixes bug where `Namespace` argument sometimes goes missing.