### PR TITLE
fix: PutMetricData permissions by default

### DIFF
--- a/src/DeploymentSafetyEnforcer.ts
+++ b/src/DeploymentSafetyEnforcer.ts
@@ -218,7 +218,7 @@ export class DeploymentSafetyEnforcer extends Construct {
       }
     }
 
-    if (props.metrics?.enabled) {
+    if (props.metrics?.enabled !== false) {
       enforcerFunction.addToRolePolicy(
         new iam.PolicyStatement({
           effect: iam.Effect.ALLOW,

--- a/test/CodePipelineHelper.test.ts
+++ b/test/CodePipelineHelper.test.ts
@@ -71,3 +71,15 @@ test('Event Bridge rule input', () => {
     ]),
   });
 });
+
+test('Enforcer role', () => {
+  template.hasResourceProperties('AWS::IAM::Policy', {
+    PolicyDocument: Match.objectLike({
+      Statement: Match.arrayWith([
+        Match.objectLike({
+          Action: 'cloudwatch:PutMetricData',
+        }),
+      ]),
+    }),
+  });
+});


### PR DESCRIPTION
As in other sections, the default is "on".